### PR TITLE
script to create initial version.php file

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,17 @@
+### git-pull.sh needs this
+mkdir site
+
+### Update the libs and populate download/version.php
+cd download
+touch version.php
+
+# Call release.php, which populates the version file
+php -r '$_GET["f"] = "update_lib" ; $jside_version=""; include("release.php");'
+php -r '$_GET["f"] = "update_jside" ; include("release.php");'
+echo ""
+echo "New version.php looks like this:"
+cat version.php
+echo ""
+echo ""
+cd - &>/dev/null
+


### PR DESCRIPTION
This may not be the best way to go about it fixing it, but a freshly-cloned instance of p5js.org produces several warnings because there is no initial download/version.php. Running git-clone.php also results in an error because there is no site/ directory by default. This script does everything needed to eliminate the warnings I have seen so far, except for the warning addressed in https://github.com/lmccart/p5js.org/pull/68